### PR TITLE
Убрано двойное закругление в Glide, добавлен белый фон в логотип

### DIFF
--- a/app/src/main/java/ru/practicum/android/diploma/ui/vacancy/VacancyDetailsFragment.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/ui/vacancy/VacancyDetailsFragment.kt
@@ -4,7 +4,6 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.core.net.toUri
 import androidx.core.os.bundleOf
 import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
@@ -14,6 +13,7 @@ import androidx.lifecycle.repeatOnLifecycle
 import androidx.navigation.fragment.findNavController
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.bumptech.glide.Glide
+import com.bumptech.glide.load.engine.DiskCacheStrategy
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 import org.koin.androidx.viewmodel.ext.android.viewModel
@@ -25,6 +25,7 @@ import ru.practicum.android.diploma.domain.models.Vacancy
 import ru.practicum.android.diploma.domain.models.VacancySource
 import ru.practicum.android.diploma.presentation.vacancy.VacancyDetailsViewModel
 import ru.practicum.android.diploma.ui.adapters.PhoneAdapter
+import ru.practicum.android.diploma.util.ImageUtil.normalizeLogoUrl
 import ru.practicum.android.diploma.util.UtilFunctions.formatSalary
 
 class VacancyDetailsFragment : Fragment() {
@@ -126,8 +127,10 @@ class VacancyDetailsFragment : Fragment() {
             vacancyDetailsScroll.isVisible = true
 
             Glide.with(requireContext())
-                .load(vacancy.employerLogoPath?.toUri())
+                .load(normalizeLogoUrl(vacancy.employerLogoPath))
+                .diskCacheStrategy(DiskCacheStrategy.ALL)
                 .placeholder(R.drawable.ic_employer_logo_placeholder_48)
+                .error(R.drawable.ic_employer_logo_placeholder_48)
                 .into(companyLogo)
 
             vacancyName.text = vacancy.name

--- a/app/src/main/java/ru/practicum/android/diploma/ui/viewholders/VacancyViewHolder.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/ui/viewholders/VacancyViewHolder.kt
@@ -4,9 +4,10 @@ import android.view.View
 import android.widget.ImageView
 import android.widget.TextView
 import com.bumptech.glide.Glide
-import com.bumptech.glide.load.resource.bitmap.RoundedCorners
+import com.bumptech.glide.load.engine.DiskCacheStrategy
 import ru.practicum.android.diploma.R
 import ru.practicum.android.diploma.domain.models.Vacancy
+import ru.practicum.android.diploma.util.ImageUtil.normalizeLogoUrl
 import ru.practicum.android.diploma.util.OnItemClickListener
 import ru.practicum.android.diploma.util.UtilFunctions
 
@@ -22,11 +23,13 @@ class VacancyViewHolder(itemView: View, private val onClickListener: OnItemClick
 
     override fun bind(vacancy: Vacancy) {
         itemView.setOnClickListener { onClickListener.onItemClick(vacancy.id) }
+
         Glide.with(context)
-            .load(vacancy.employerLogoPath)
+            .load(normalizeLogoUrl(vacancy.employerLogoPath))
+            .diskCacheStrategy(DiskCacheStrategy.ALL)
             .placeholder(R.drawable.ic_employer_logo_placeholder_48)
+            .error(R.drawable.ic_employer_logo_placeholder_48)
             .centerInside()
-            .transform(RoundedCorners(context.resources.getDimensionPixelSize(R.dimen.dimen_12dp)))
             .into(vacancyIcon)
 
         vacancyTitle.text =

--- a/app/src/main/java/ru/practicum/android/diploma/util/ImageUtil.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/util/ImageUtil.kt
@@ -1,0 +1,16 @@
+package ru.practicum.android.diploma.util
+
+object ImageUtil {
+
+    fun normalizeLogoUrl(url: String?): String? {
+        if (url.isNullOrBlank()) return null
+
+        return when {
+            url.endsWith(".png", ignoreCase = true) -> url
+
+            url.endsWith(".svg", ignoreCase = true) -> null
+
+            else -> url
+        }
+    }
+}

--- a/app/src/main/res/layout/vacancy_list_item.xml
+++ b/app/src/main/res/layout/vacancy_list_item.xml
@@ -12,6 +12,7 @@
         android:layout_width="@dimen/vacancy_logo_size"
         android:layout_height="@dimen/vacancy_logo_size"
         android:scaleType="fitCenter"
+        android:background="@color/white_universal"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
         app:shapeAppearanceOverlay="@style/RoundedLogoShape"


### PR DESCRIPTION
Убрано двойное закругление в Glide, добавлен белый фон в логотип
Логотипы отображаются не у всех компаний(Яндекс) - логотипы битые, провел анализ, улучшил приложение на стабильность к данным ошибкам